### PR TITLE
Fixes issues with unable to traverse in slow wave

### DIFF
--- a/src/ui/panels/uimain/uiprimary/uiview/uiinfo/uiinfomain/uiinfomain_axes.m
+++ b/src/ui/panels/uimain/uiprimary/uiview/uiinfo/uiinfomain/uiinfomain_axes.m
@@ -30,7 +30,7 @@ classdef uiinfomain_axes < TComponent
         
         function traverseFcn(obj)
             cp = obj.CurrentPosition;
-            sz = obj.Data.cnfg.size;
+            sz = obj.Data.cnfg.size([2 1]);
 
             if all(cp > 0.5 & cp < sz + 0.5)
                 set(obj.rc, ...


### PR DESCRIPTION
Changes index order for electrode size so traversing works as expected for non-square electrode array config