### PR TITLE
Bug fixes

### DIFF
--- a/src/data/DataContainer.m
+++ b/src/data/DataContainer.m
@@ -138,10 +138,10 @@ classdef DataContainer < dynamicprops
 
         function initialise(obj)
             % Find path containing data types
-            s = what('src/data/types');
+            s = what(fullfile('src','data','types'));
 
             % Create list of file names
-            fl = dir(fullfile(s.path, '**\*.*'));
+            fl = dir(fullfile(s.path, '**','*.*'));
             fl = fl(~[fl.isdir]);
 
             % Create table containing object handles

--- a/src/ui/panels/uimain/uiprimary/uiview/uisignal/uisignalmain/axesgraphics/uisignalmain_select.m
+++ b/src/ui/panels/uimain/uiprimary/uiview/uisignal/uisignalmain/axesgraphics/uisignalmain_select.m
@@ -51,7 +51,7 @@ classdef uisignalmain_select < TComponent
 
                 c = obj.Data.uisign.indices;
 
-                tf = (c > 0) & (c < obj.Data.prop.channels);
+                tf = (c > 0) & (c <= obj.Data.prop.channels);
 
                 it = obj.Data.uiprvw.at(obj.Data.uisign.indices_grid);
                 it = round(it * obj.Data.filt.frequency) + 1;

--- a/src/ui/panels/uimain/uiproperties/uiconfig/uiconfig_axes_sphere.m
+++ b/src/ui/panels/uimain/uiproperties/uiconfig/uiconfig_axes_sphere.m
@@ -79,6 +79,10 @@ classdef uiconfig_axes_sphere < TComponent
         end
         function mouseDrag(obj)
             p = get(0, 'PointerLocation');
+            if isempty(obj.clicked)
+                return
+            end
+            
             v = obj.Handle.View + (obj.clicked - p);
             v(2) = max(min(v(2), +45), -60);
 


### PR DESCRIPTION
Hard-coded Windows OS specific file separator characters were causing BEZOAR start-up to fail on Mac. Addressed by using the inbuilt fullfile function.